### PR TITLE
Abbreviated long options are properly parsed

### DIFF
--- a/lib/tty/option/parser/options.rb
+++ b/lib/tty/option/parser/options.rb
@@ -175,7 +175,12 @@ module TTY
                 @remaining << long
               end
             elsif matching_options == 1
-              value = long[opt.long_name.size..-1]
+              # option stuck together with the argument
+              if sep.nil? && rest.empty?
+                value = long[opt.long_name.size..-1]
+              else
+                value = rest
+              end
             else
               @error_aggregator.(AmbiguousOption.new("option '#{long}' is ambiguous"))
             end

--- a/spec/unit/parser/options_spec.rb
+++ b/spec/unit/parser/options_spec.rb
@@ -224,6 +224,12 @@ RSpec.describe TTY::Option::Parser::Options do
     expect(params[:foo]).to eq("bar")
   end
 
+  it "parses long option abbreviated and defined with =" do
+    params, = parse(%w[--fo=bar], option(:foo, long: "--foo=string"))
+
+    expect(params[:foo]).to eq("bar")
+  end
+
   it "raises if long option isn't defined" do
     expect {
       parse(%w[--foo --bar], option(:foo, long: "--foo"),


### PR DESCRIPTION
When an abbreviated form of a long options is passed as argv, the value of it wasn't properly extracted.
A unit test was added to reproduce the issue and the code to fix it.

Fixes #5

### Describe the change
This PR is intended to fix this situation: If you have a required `--environment=string` flag defined and your `argv` is `--env=staging`, the parsing process considers `--env` as a valid `--environment=string` but the staging value is not properly set to the option.

### Why are we doing this?
When an abbreviated form of a long options is passed as argv, the value of it wasn't properly extracted.
Use this UT as a way to reproduce the issue:
```ruby
  it "parses long option abbreviated and defined with =" do
    params, = parse(%w[--fo=bar], option(:foo, long: "--foo=string"))

    expect(params[:foo]).to eq("bar")
  end
```

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [X] Tests written & passing locally?
- [X] Code style checked?
- [X] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated?
