### PR TITLE
Fix typo README section '2.5.6 name'

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ params[:foo_bar] # => "baz"
 To change the parameter name to a custom one, use the `name` setting:
 
 ```ruby
-keywor :foo_bar do
+keyword :foo_bar do
   name "fum"
 end
 ```


### PR DESCRIPTION
### Describe the change
Just adding a missing 'd' in 'keyword' to a code block in the [name](https://github.com/piotrmurach/tty-option#256-name) section . 

Cheers to you for this splendid lib.

### Why are we doing this?
So much love was obviously put into the documentation, I could not stand idly by at the opportunity to wipe this rogue smudge from the glass.

### Benefits
People will think this gem has top notch spelling skills.

### Drawbacks
We've shown our hand. Now they know we know how to spell 'keyword'. The jig is up.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [ ] Tests written & passing locally?
- [ ] Code style checked?
- [ ] Rebased with `master` branch?
- [x] Documentation updated?
- [ ] Changelog updated?
