### PR TITLE
Allow arguments to be hardcoded strings with - and = characters

### DIFF
--- a/lib/tty/option/parser/param_types.rb
+++ b/lib/tty/option/parser/param_types.rb
@@ -6,6 +6,7 @@ module TTY
       module ParamTypes
         # Positional argument pattern
         ARGUMENT_PARAMETER = /^[^-][^=]*\z/.freeze
+        ARGUMENT_HARDCODED_STRING = /\s/.freeze
 
         # Environment variable pattern
         ENV_VAR_PARAMETER = /^[\p{Lu}_\-\d]+=/.freeze
@@ -24,7 +25,8 @@ module TTY
         #
         # @api public
         def argument?(value)
-          !value.match(ARGUMENT_PARAMETER).nil?
+          !value.match(ARGUMENT_PARAMETER).nil? ||
+            !value.match(ARGUMENT_HARDCODED_STRING).nil?
         end
 
         # Check if value is an environment variable

--- a/spec/unit/parse_spec.rb
+++ b/spec/unit/parse_spec.rb
@@ -6,6 +6,15 @@ require "uri"
 
 RSpec.describe TTY::Option do
   context "argument" do
+    it "parses a hardcoded string with spaces as an argument" do
+      cmd = new_command do
+        argument :foo
+      end
+
+      cmd.parse(["bar TEST=something"])
+      expect(cmd.params[:foo]).to eq("bar TEST=something")
+    end
+
     it "doesn't allow to register same name parameter" do
       expect {
         command do

--- a/spec/unit/parser/param_types_spec.rb
+++ b/spec/unit/parser/param_types_spec.rb
@@ -9,12 +9,13 @@ RSpec.describe TTY::Option::Parser::ParamTypes do
 
   context "argument?" do
     {
-      "--foo"   => false,
-      "-f"      => false,
-      "foo=bar" => false,
-      "foo"     => true,
-      "f"       => true,
-      "FOO=bar" => false
+      "--foo"                   => false,
+      "-f"                      => false,
+      "foo=bar"                 => false,
+      "foo"                     => true,
+      "f"                       => true,
+      "FOO=bar"                 => false,
+      "something FOO=bar --foo" => true
     }.each do |input, result|
       it "returns #{result} for #{input.inspect}" do
         expect(type.argument?(input)).to eq(result)
@@ -24,13 +25,14 @@ RSpec.describe TTY::Option::Parser::ParamTypes do
 
   context "env_var?" do
     {
-      "--foo"   => false,
-      "-f"      => false,
-      "foo=bar" => false,
-      "a=b"     => false,
-      "foo"     => false,
-      "FOO=bar" => true,
-      "A=b"     => true
+      "--foo"                   => false,
+      "-f"                      => false,
+      "foo=bar"                 => false,
+      "a=b"                     => false,
+      "foo"                     => false,
+      "FOO=bar"                 => true,
+      "A=b"                     => true,
+      "something FOO=bar --foo" => false
     }.each do |input, result|
       it "returns #{result} for #{input.inspect}" do
         expect(type.env_var?(input)).to eq(result)
@@ -40,13 +42,14 @@ RSpec.describe TTY::Option::Parser::ParamTypes do
 
   context "keyword?" do
     {
-      "--foo"   => false,
-      "-f"      => false,
-      "-fa=b"   => false,
-      "foo=bar" => true,
-      "a=b"     => true,
-      "foo"     => false,
-      "FOO=bar" => false
+      "--foo"                   => false,
+      "-f"                      => false,
+      "-fa=b"                   => false,
+      "foo=bar"                 => true,
+      "a=b"                     => true,
+      "foo"                     => false,
+      "FOO=bar"                 => false,
+      "something FOO=bar --foo" => false
     }.each do |input, result|
       it "returns #{result} for #{input.inspect}" do
         expect(type.keyword?(input)).to eq(result)
@@ -56,12 +59,13 @@ RSpec.describe TTY::Option::Parser::ParamTypes do
 
   context "option?" do
     {
-      "--foo"   => true,
-      "-f"      => true,
-      "foo=bar" => false,
-      "foo"     => false,
-      "f"       => false,
-      "FOO=bar" => false
+      "--foo"                   => true,
+      "-f"                      => true,
+      "foo=bar"                 => false,
+      "foo"                     => false,
+      "f"                       => false,
+      "FOO=bar"                 => false,
+      "something FOO=bar --foo" => false
     }.each do |input, result|
       it "returns #{result} for #{input.inspect}" do
         expect(type.option?(input)).to eq(result)


### PR DESCRIPTION
### Describe the change
This pull request allows `:argument` option to be a hardcoded string representing a command that can contain args and env variables.

**Note: Please advise if there is another way to define an argument to would allow a hardcoded string with special characters like = and -**

Ex: `my-cli --notify 'bundle exec rake TEST=<test>'`

```ruby
module Retest
  class Options
    include TTY::Option

    argument :command do
      optional
      desc <<~EOS
      The test command to rerun when a file changes.
      Use <test> or <changed> placeholders to tell retest where to reference the matching spec or the changed file in the command.
      EOS
    end

    flag :notify do
      long "--notify"
      desc "Play a sound when specs pass or fail (macOS only)"
    end
  end
end
```

### Why are we doing this?
I have a gem trying to parse a string like this `'my-command FILE=<test>'` as an argument and currently fails to parse the command properly. TTY::Option returns `nil` when a `=` or `-` is used in the string.

Any related context as to why is this is a desirable change.
Here is the issue: https://github.com/AlexB52/retest/issues/81

### Benefits
Meta: We can pass a hardcoded string as an argument using ENV variables and flags.

### Drawbacks
* We could have an arg matched as multiple parameter types if not tested properly.
* The regex used to identify whether it's hardcoded command look a bit weak as we're only checking for the presence of spaces in the string.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [X] Tests written & passing locally?
- [X] Code style checked?
- [X] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated?


